### PR TITLE
Adds support for multiple imports from single source.

### DIFF
--- a/mochi/mochi.py
+++ b/mochi/mochi.py
@@ -2673,7 +2673,8 @@ class Translator(object):
         names = [ast.alias(name=import_sym.name,
                            asname=None,
                            lineno=import_sym.lineno,
-                           col_offset=import_sym.col_offset) for import_sym in exp[2:]]
+                           col_offset=import_sym.col_offset) for import_sym_names in exp[2:]
+                                                             for import_sym in import_sym_names]
         return (ast.ImportFrom(module=exp[1].name,
                                names=names,
                                level=0,

--- a/mochi/parser.py
+++ b/mochi/parser.py
@@ -294,9 +294,9 @@ def tuple_elt(p):
     return p[0]
 
 
-@pg.production('from_expr : FROM names IMPORT NAME')
+@pg.production('from_expr : FROM names IMPORT namelist')
 def from_expr(p):
-    return [Symbol('from-import'), p[1], token_to_symbol(p[3])]
+    return [Symbol('from-import'), p[1], p[3]]
 
 
 @pg.production('suite : binop_expr')  # TODO multi


### PR DESCRIPTION
Adds support for statements of the type:

```
from flask import Flask, render_template 
```
