### PR TITLE
Short form for keyword arguments and dict keys

### DIFF
--- a/examples/keyword_arguments.mochi
+++ b/examples/keyword_arguments.mochi
@@ -1,0 +1,9 @@
+def foo(a, b, c):
+    a + b + c
+    
+a = 1
+b = 2
+c = 3
+
+print(foo(=a, =b, =c))  # This is the same as foo(a=a, b=b, c=c)
+print({=a, =b})  # This is the same as {'a': a, 'b': b}

--- a/mochi/parser.py
+++ b/mochi/parser.py
@@ -844,6 +844,13 @@ def app_args_elt(p):
     return [token_to_keyword(p[0]), p[2]]
 
 
+@pg.production('app_args_elt : EQUALS binop_expr')
+def app_args_elt_short(p):
+    s = p[1]
+    assert isinstance(s, Symbol)
+    return [Keyword(s.name, s.lineno, s.col_offset), p[1]]
+
+
 @pg.production('app_args_elt : binop_expr')
 def app_args_elt(p):
     return [p[0]]
@@ -918,6 +925,13 @@ def list_field(p):
 @pg.production('field : key COLON binop_expr')
 def field(p):
     return [p[0], p[2]]
+
+
+@pg.production('field : EQUALS binop_expr')
+def field(p):
+    s = p[1]
+    assert isinstance(s, Symbol)
+    return [p[1].name, p[1]]
 
 
 @pg.production('key : binop_expr')


### PR DESCRIPTION
I would love to have this feature in Python, but that won't happen, so here it is in Mochi instead! :P

The basic idea is to make it a lot easier to use a lot of keyword arguments in ones code. I know at work there's a lot of

``` python
def foo(long_name, another_name, third_name, forth_name, fifth_name):
    do_something_with(long_name)
    something_else(another_name, third_name, forth_name, fifth_name)

def something_else(another_name, third_name, forth_name, fifth_name):
    ....
    something
    ....
```

this could would be a lot more robust when adding or removing parameters if keyword arguments were used, but they are not because it becomes too long to write and read. This patch would make that case a lot nicer I think.

Hope you like it.
