### PR TITLE
Prepare project for Python 3.5 to be released next year

### DIFF
--- a/mochi/__init__.py
+++ b/mochi/__init__.py
@@ -5,4 +5,4 @@ __license__ = 'MIT License'
 
 import sys
 
-IS_PYTHON_34 = sys.version_info.major == 3 and sys.version_info.minor == 4
+IS_PYTHON_34 = sys.version_info >= (3, 4)

--- a/mochi/mochi.py
+++ b/mochi/mochi.py
@@ -28,7 +28,7 @@ from mochi import actor
 from mochi import __version__
 
 
-IS_PYTHON_34 = sys.version_info.major == 3 and sys.version_info.minor == 4
+IS_PYTHON_34 = sys.version_info >= (3, 4)
 IS_PYPY = platform.python_implementation() == 'PyPy'
 
 


### PR DESCRIPTION
This commit changes the `IS_PYTHON_34` constants to be "at least" Python 3.4. This prepares the project for future releases of Python 3, including Python 3.5 which will be released next year.
