### PR TITLE
Feature/intermediate step debug output

### DIFF
--- a/mochi/core/builtins.py
+++ b/mochi/core/builtins.py
@@ -14,7 +14,7 @@ from .utils import issequence, issequence_except_str, is_tuple_or_list
 from .constants import *
 from .exceptions import UnquoteSplicingError, DuplicatedDefError, ReadError
 from .global_env import global_env
-from mochi.parser.parser import lex
+from mochi.parser import lex
 from .translation import binding_name_set_stack, translator, Keyword, parse
 
 

--- a/mochi/core/global_env.py
+++ b/mochi/core/global_env.py
@@ -1,17 +1,24 @@
-from collections import Iterable, Mapping, MutableMapping, Sequence, MutableSequence
+from collections import (
+    Iterable,
+    Mapping,
+    MutableMapping,
+    Sequence,
+    MutableSequence
+)
 import functools
 import itertools
 from numbers import Number
 import operator
 import re
-import sys
 
-from pyrsistent import (v, pvector, m, pmap, s, pset, b, pbag, dq, pdeque, l,
-                        plist, immutable, freeze, thaw, CheckedPVector, PVector, PMap, PSet,
-                        _PList, _PBag)
+from pyrsistent import (
+    v, pvector, m, pmap, s, pset, b, pbag, dq, pdeque, l,
+    plist, immutable, freeze, thaw, CheckedPVector, PVector,
+    PMap, PSet, _PList, _PBag
+)
 from mochi import IS_PYPY
 from mochi.actor import actor
-from mochi.parser.parser import Symbol, Keyword, get_temp_name
+from mochi.parser import Symbol, Keyword, get_temp_name
 if not IS_PYPY:
     from annotation.typed import union, options, optional, only, predicate
 

--- a/mochi/core/main.py
+++ b/mochi/core/main.py
@@ -7,7 +7,7 @@ from platform import platform
 
 from mochi import __version__, IS_PYPY, GE_PYTHON_34, GE_PYTHON_33
 from .builtins import current_error_port, eval_sexp_str, eval_tokens
-from mochi.parser.parser import lex, REPL_CONTINUE
+from mochi.parser import lex, REPL_CONTINUE
 from .global_env import global_env
 from .translation import syntax_table, global_scope, translator
 

--- a/mochi/core/translation.py
+++ b/mochi/core/translation.py
@@ -10,7 +10,7 @@ from .constants import *
 from .exceptions import MochiSyntaxError, DuplicatedDefError
 from .global_env import global_env
 from mochi import GE_PYTHON_34, IS_PYPY
-from mochi.parser.parser import Symbol, Keyword, parse, lex, get_temp_name
+from mochi.parser import Symbol, Keyword, parse, lex, get_temp_name
 
 
 if GE_PYTHON_34:

--- a/mochi/core/translation.py
+++ b/mochi/core/translation.py
@@ -100,11 +100,11 @@ class Translator(object):
         self.macro_table = macro_table
         self.filename = filename
 
-    def translate_file(self, filename):
+    def translate_file(self, filename, show_tokens=False):
         body = []
         self.filename = filename
         with open(filename, 'r') as f:
-            sexps = parse(lex(f.read()))
+            sexps = parse(lex(f.read(), debug=show_tokens))
             chdir(normpath(str(Path(filename).parent)))
             for sexp in sexps:
                 if isinstance(sexp, MutableSequence):
@@ -116,11 +116,11 @@ class Translator(object):
                 body.append(self.enclose(value, True))
         return ast.Module(body=body)
 
-    def translate_loaded_file(self, filename):
+    def translate_loaded_file(self, filename, show_tokens=False):
         body = []
         self.filename = filename
         with open(filename, 'r') as f:
-            sexps = parse(lex(f.read()))
+            sexps = parse(lex(f.read(), debug=show_tokens))
             for sexp in sexps:
                 if isinstance(sexp, MutableSequence):
                     sexp = tuple_it(sexp)

--- a/mochi/parser/__init__.py
+++ b/mochi/parser/__init__.py
@@ -1,0 +1,2 @@
+from mochi.parser.lexer import lex, REPL_CONTINUE
+from mochi.parser.parser import parse, Symbol, Keyword, get_temp_name

--- a/mochi/parser/lexer.py
+++ b/mochi/parser/lexer.py
@@ -1,4 +1,92 @@
-from rply import LexerGenerator
+from queue import Queue
+
+from rply import LexerGenerator, Token
+
+REPL_CONTINUE = object()
+
+
+def mod_lex(lexer, repl_mode=False):
+    paren_openers = {'LPAREN', 'LBRACE', 'LBRACK'}
+    paren_closers = {'RPAREN', 'RBRACE', 'RBRACK'}
+
+    token_queue = Queue()
+    indent_level = [0]
+    ignore_newline = False
+    paren_level = 0
+    tab_len = 4
+
+    def handle_newline(token):
+        text = token.getstr()
+        indent_str = text.rsplit('\n', 1)[1]
+        indent = indent_str.count(' ') + indent_str.count('\t') * tab_len
+        if indent > indent_level[-1]:
+            indent_level.append(indent)
+            indent_token = Token('INDENT', indent_str)
+            indent_token.source_pos = token.getsourcepos()
+            token_queue.put(indent_token)
+        else:
+            while indent < indent_level[-1]:
+                indent_level.pop()
+                dedent_token = Token('DEDENT', indent_str)
+                token_queue.put(dedent_token)
+        return token
+
+    for token in lexer:
+        while not token_queue.empty():
+            queued_token = token_queue.get()
+            if queued_token.gettokentype() in paren_openers:
+                paren_level += 1
+            elif queued_token.gettokentype() in paren_closers:
+                paren_level -= 1
+            ignore_newline = (paren_level > 0)
+            yield queued_token
+
+        if token.name == 'NAME':
+            for rule in klg.rules:
+                if rule.matches(token.value, 0):
+                    token.name = rule.name
+                    break
+        elif token.gettokentype() == 'NEWLINE':
+            if not ignore_newline:
+                yield handle_newline(token)
+            continue
+
+        if token.gettokentype() in paren_openers:
+            paren_level += 1
+        elif token.gettokentype() in paren_closers:
+            paren_level -= 1
+        ignore_newline = (paren_level > 0)
+
+        if token.gettokentype() == 'NAME' and token.getstr().startswith('&'):
+            amp = Token('AMP', '&')
+            amp.source_pos = token.getsourcepos()
+            comma = Token('COMMA', ',')
+            amp.source_pos = token.getsourcepos()
+            name = Token('NAME', token.getstr()[1:])
+            name.source_pos = token.getsourcepos()
+            yield amp
+            yield comma
+            yield name
+        else:
+            yield token
+
+    if repl_mode and len(indent_level) > 1:
+        yield REPL_CONTINUE
+    elif repl_mode and paren_level > 0:
+        yield REPL_CONTINUE
+    else:
+        while len(indent_level) > 1:
+            indent_level.pop()
+            yield Token('DEDENT', '')
+
+        while not token_queue.empty():
+            yield token_queue.get()
+
+
+def lex(input, repl_mode=False):
+    return mod_lex(lg.build().lex(input), repl_mode)
+
+
 
 lg = LexerGenerator()
 

--- a/mochi/parser/lexer.py
+++ b/mochi/parser/lexer.py
@@ -1,3 +1,4 @@
+import sys
 from queue import Queue
 
 from rply import LexerGenerator, Token
@@ -83,9 +84,11 @@ def mod_lex(lexer, repl_mode=False):
             yield token_queue.get()
 
 
-def lex(input, repl_mode=False):
-    return mod_lex(lg.build().lex(input), repl_mode)
+def lex(input, repl_mode=False, debug=True):  # TODO
+    if debug:
+        print(list(mod_lex(lg.build().lex(input), repl_mode)), file=sys.stderr)
 
+    return mod_lex(lg.build().lex(input), repl_mode)
 
 
 lg = LexerGenerator()


### PR DESCRIPTION
Plus some additional cleanup.

Usage:
```
mochi --show-tokens
```
Will drop you into the repl, and each thing you type will display the results of the tokenizing step.
```
mochi -c <file-name> > <compiled_file>
```
Will compile a file into the specified name, but still print the results of the tokenizing step to the terminal (because it is printing to stderr).

Could someone give a review before the merge? I don't think this breaks anything, but I wouldn't mind a second set of eyes.