### PR TITLE
Generation of Python Source from Mochi Code

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -53,3 +53,7 @@ doc/*.html
 doc/*.pdf
 # PyBuilder
 target/
+
+# Wing IDE project settings
+mochi.wpr
+mochi.wpu

--- a/.gitignore
+++ b/.gitignore
@@ -57,3 +57,7 @@ target/
 # Wing IDE project settings
 mochi.wpr
 mochi.wpu
+
+# Temp
+tmp/
+temp/

--- a/mochi/core/main.py
+++ b/mochi/core/main.py
@@ -302,9 +302,11 @@ def main():
             elif args.pyc_compile:
                 if args.no_monkeypatch:
                     pyc_compile_no_monkeypatch(in_file_name=args.file,
+                                               out_file_name=args.outfile,
                                                show_tokens=args.tokens)
                 else:
                     pyc_compile_monkeypatch(in_file_name=args.file,
+                                            out_file_name=args.outfile,
                                             show_tokens=args.tokens)
             elif args.py_source:
                 make_py_source_file(mochi_file_name=args.file,

--- a/mochi/core/main.py
+++ b/mochi/core/main.py
@@ -272,8 +272,8 @@ def parse_args():
                             action='store_true')
     arg_parser.add_argument('-init', '--add-init-code', action='store_true',
                             help='Add Mochi init code to Python source code '
-                                 'files. This allows running the from the '
-                                 'command line with Python.')
+                                 'files. This allows running the generated '
+                                 'file from the command line with Python.')
     arg_parser.add_argument('-e', '--execute-compiled-file',
                             action='store_true')
     arg_parser.add_argument('file', nargs='?', type=str)

--- a/mochi/core/translation.py
+++ b/mochi/core/translation.py
@@ -484,7 +484,7 @@ class Translator(object):
                                lineno=op_symbol.lineno,
                                col_offset=0)
 
-    @syntax('=', '!=', '<', '<=', '>', '>=',
+    @syntax('=', '==', '!=', '<', '<=', '>', '>=',
             'is', 'is_not', 'in', 'not_in')
     def translate_compare(self, exp):
         if len(exp) < 3:

--- a/mochi/core/translation.py
+++ b/mochi/core/translation.py
@@ -484,7 +484,7 @@ class Translator(object):
                                lineno=op_symbol.lineno,
                                col_offset=0)
 
-    @syntax('=', '==', '!=', '<', '<=', '>', '>=',
+    @syntax('==', '!=', '<', '<=', '>', '>=',
             'is', 'is_not', 'in', 'not_in')
     def translate_compare(self, exp):
         if len(exp) < 3:

--- a/mochi/utils/path_helper.py
+++ b/mochi/utils/path_helper.py
@@ -1,0 +1,33 @@
+"""Helpers for working with paths an similar.
+"""
+
+import os
+
+
+class TempDir(object):
+    """Switch to a temporary directory and back.
+
+    This is a context manager.
+
+    usage:
+
+        # in orig_dir
+        with TempDir('/path/to/temp_dir'):
+            # in temp_dir
+            do_something_in_temp_dir()
+        # back in orig_dir
+
+
+    """
+    # pylint: disable=too-few-public-methods
+
+    def __init__(self, temp_dir):
+        self.temp_dir = temp_dir
+
+    def __enter__(self):
+        # pylint: disable=attribute-defined-outside-init
+        self.orig_dir = os.getcwd()
+        os.chdir(self.temp_dir)
+
+    def __exit__(self, *args):
+        os.chdir(self.orig_dir)

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,3 +6,4 @@ pyzmq>=14.5.0
 msgpack-python>=0.4.6
 kazoo>=2.0
 typeannotations>=0.1.0
+astunparse>=1.2.2

--- a/tests/check_py_source.py
+++ b/tests/check_py_source.py
@@ -42,7 +42,7 @@ def check_py_syntax(src_path, dst_path):
         with TempDir(dst_path):
             try:
                 py_compile.compile('{}.py'.format(mod_name), doraise=True)
-            except Exception as err:
+            except Exception as err:  # pylint: disable=broad-except
                 print('#' * 30)
                 print('Error in module', mod_name)
                 print('#' * 30)

--- a/tests/check_py_source.py
+++ b/tests/check_py_source.py
@@ -1,0 +1,66 @@
+"""Generate Python source files from Mochi files and check for valid syntax.
+"""
+
+import glob
+import os
+import py_compile
+
+from mochi.core.main import make_py_source_file, MONKEY_PATCH_ENV
+from mochi.utils.path_helper import TempDir
+
+
+def make_target_file_name(file_name, dst_path, ext):
+    """Make Python source file name."""
+    target_file_name = os.path.splitext(os.path.basename(file_name))[0]
+    target_file_name += '.' + ext
+    target_file_name = os.path.join(dst_path, target_file_name)
+    return target_file_name
+
+
+def check_py_syntax(src_path, dst_path):
+    """Check the Python syntax."""
+    if not os.path.exists(src_path):
+        os.makedirs(dst_path)
+    good = []
+    bad = []
+    for file_name in glob.glob(os.path.join(src_path, '*.mochi')):
+        mod_name = os.path.splitext(os.path.basename(file_name))[0]
+        py_file_name = make_target_file_name(file_name, dst_path, 'py')
+        with TempDir(src_path):
+            try:
+                make_py_source_file(mochi_file_name=file_name,
+                                    python_file_name=py_file_name,
+                                    mochi_env=MONKEY_PATCH_ENV,
+                                    add_init=True, show_tokens=False)
+            except TypeError as err:
+                print('#' * 30)
+                print('Error in module', mod_name)
+                print('#' * 30)
+                print(err)
+                bad.append(mod_name)
+                continue
+        with TempDir(dst_path):
+            try:
+                py_compile.compile('{}.py'.format(mod_name), doraise=True)
+            except Exception as err:
+                print('#' * 30)
+                print('Error in module', mod_name)
+                print('#' * 30)
+                print(err)
+                bad.append(mod_name)
+                continue
+        good.append(mod_name)
+
+    print('good', good)
+    print('bad', bad)
+
+if __name__ == '__main__':
+
+    def check_examples():
+        """Check Mochi files in example dir."""
+        cwd = os.getcwd()
+        src_path = os.path.normpath(os.path.join(cwd, '../examples'))
+        dst_path = os.path.normpath(os.path.join(cwd, '../tmp'))
+        check_py_syntax(src_path, dst_path)
+
+    check_examples()


### PR DESCRIPTION
This adds the capability to translate Mochi source files into Python source files.
Furthermore, it allows to generate a pretty-printed AST for a Mochi source file. 

It uses the external library `astunparse`.

These are the new commandline options:

```
-py, --py-source      Generate Python source code from Mochi file.
-a, --ast             Generate AST from Mochi file.
-o [OUTFILE], --outfile [OUTFILE]
                      Name of output file.

-init, --add-init-code
                      Add Mochi init code to Python source code files. This
                      allows running the generated file from the command
                      line with Python.
```

There is a new test script `check_py_source.py` in the test dir. It converts all Mochi sources files in the `example` dir into Python source files.

There a several problems with the generated code. The function `mochi.core.main.clean_source()` is a dirty hack to clean some of the problems. It is not designed to stay but to point out the problems. They should be fixed in the AST generation code. 

Even though the syntax is correct, the script might not run with Python. There needs to be another check that actually executes the programs.

In general, generation of Python source, not only bytecode, seems desirable. It can be very useful for debugging. Many tools work only with source code and not with bytecode.

Using Python source should open new possibilities for the IPython Notebook integration. With this generated Python source, we might be able to use most of the existing magic functions for timing and many more tasks.
