### PR TITLE
Set debug to false as default to avoid tokens to be displayed in IPyt…

### DIFF
--- a/mochi/parser/lexer.py
+++ b/mochi/parser/lexer.py
@@ -149,7 +149,7 @@ def mod_lex(lexer, repl_mode=False):
             yield Token('DEDENT', '')
 
 
-def lex(input, repl_mode=False, debug=True):
+def lex(input, repl_mode=False, debug=False):
     if debug:
         print(list(mod_lex(lg.build().lex(input), repl_mode)), file=sys.stderr)
 


### PR DESCRIPTION
…hon Notebooks.

Debug was on `True`  by default which results in a lot of noisy debug output in IPython Notebooks. Having it on `False` seems much more reasonable.