### PR TITLE
Remove duplicate lines.

### DIFF
--- a/mochi/core/main.py
+++ b/mochi/core/main.py
@@ -37,11 +37,9 @@ def output_pyc(code, buffer=sys.stdout.buffer):
 
     buffer.write(MAGIC_NUMBER)
     timestamp = struct.pack('i', int(time.time()))
+    buffer.write(timestamp)
     if GE_PYTHON_33:
-        buffer.write(timestamp)
         buffer.write(b'0' * 4)
-    else:
-        buffer.write(timestamp)
     marshal.dump(code, buffer)
     buffer.flush()
 


### PR DESCRIPTION
Just a small change since `buffer.write(timestamp)` is used in both the "if" and "else", it can be moved outside the condition altogether.
